### PR TITLE
Bobricius main

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ New Armachat based on Raspberry Pi PICO an Circuitpython code
 
 - Need much better LoRa library with, CAD, status detection, and INTERRUPT !!!
 - contact list
-- setup and save configuration
+- ~~setup and save configuration~~
 - save memory to flash
 
 
@@ -27,6 +27,7 @@ New Armachat based on Raspberry Pi PICO an Circuitpython code
 
 - Much more stable
 - Formatting changes in all three files. I'm using the Mu editor, <a href="https://codewith.mu/">https://codewith.mu/</a>, that has Check and Tidy functions to help standardize formatting. The formatting changes are from using those functions in the Mu editor.
+- Configuration values that  are changed may be saved to a config.txt file if the file-system is writable. 
 
 **boot.py**
 
@@ -49,6 +50,18 @@ New Armachat based on Raspberry Pi PICO an Circuitpython code
 
 **config.py**
 
-- No changes other than format
+Now reading and writing to config.txt file to keep settings between reboots
+
+Notes:
+
+- If a new property is added to config.py, it will be written to config.txt if it is one of the types included in config_includeTypes list.
+- A property may be excluded by placing it in the config_excludeNames list.
+
+Limitations
+
+- To save configuration changes, the file-system needs to be changed to writable on boot by pressing the ALT key.
+- If the config.txt file is edited by hand comments are allowed but the whole line must be a comment. Inline comments are not allowed.
+- If a hex, binary. or octal value is in the config.txt file, it will be changed to decimal if the configuration file is saved.
+- Currently only str, int, and float types are supported.
 
 BTW: Save memory to flash does work if you change the file system to write mode by pressing the ALT key when booting and pressing the S key when viewing messages.

--- a/Software/code.py
+++ b/Software/code.py
@@ -211,7 +211,8 @@ def sendMessage(text):
 
     # random.randint(min, max)
     outp = bytearray(len(text))
-    cipher = aesio.AES(config.password, aesio.MODE_CTR, config.passwordIv)
+    cipher = aesio.AES(bytes(config.password, "utf-8"),
+                       aesio.MODE_CTR, bytes(config.passwordIv, "utf-8"))
     cipher.encrypt_into(bytes(text, "utf-8"), outp)
     print("Send header:")
     print(hexlify(bytearray(header)))
@@ -286,7 +287,8 @@ def receiveMessage():
             packet_text = "D"
             return packet_text
         # Decrypt
-        cipher = aesio.AES(config.password, aesio.MODE_CTR, config.passwordIv)
+        cipher = aesio.AES(bytes(config.password, "utf-8"),
+                           aesio.MODE_CTR, bytes(config.passwordIv, "utf-8"))
         inp = bytes(packet[16:])
         outp = bytearray(len(inp))
         cipher.encrypt_into(inp, outp)
@@ -410,13 +412,16 @@ def setup():
                 if keys[0] == "f":
                     config.freq = valueUpList(FREQ_LIST, config.freq)
                     radioInit()
+                    config.writeConfig()
                 if keys[0] == "p":
                     config.power = valueUp(5, 23, config.power)
                     radioInit()
+                    config.writeConfig()
                 if keys[0] == "x":
                     config.loraProfile = valueUp(1, 6, config.loraProfile)
                     loraProfileSetup(config.loraProfile)
                     radioInit()
+                    config.writeConfig()
                 screen[0].text = "{:.d} Radio:".format(menu)
                 screen[1].text = "[F] Frequency: {:5.2f}MHz".format(config.freq)
                 screen[2].text = "[P] Power {:.d}".format(config.power)
@@ -430,6 +435,7 @@ def setup():
             elif menu == 1:
                 if keys[0] == "n":
                     config.myName = editor(text=config.myName)
+                    config.writeConfig()
                 screen[0].text = "{:.d} Identity:".format(menu)
                 screen[1].text = "[N] Name: {} ".format(config.myName)
                 screen[2].text = "------"
@@ -455,6 +461,7 @@ def setup():
                 if keys[0] == "v":
                     config.volume = valueUp(0, 6, config.volume)
                     ring()
+                    config.writeConfig()
                 screen[0].text = "{:.d} Sound:".format(menu)
                 screen[1].text = "[V] Volume {}".format(config.volume)
                 screen[2].text = ""
@@ -749,6 +756,7 @@ screen = SimpleTextDisplay(
 
 print("Screen ready,Free memory:")
 print(gc.mem_free())
+
 while True:
     screen[0].text = ">(" + str(config.myID) + ")" + config.myName
     screen[1].text = "[N] New message"

--- a/Software/config/config.py
+++ b/Software/config/config.py
@@ -1,5 +1,6 @@
 import board
 import digitalio
+import os
 
 unitName = "ARMACHAT"
 freq = 915.0
@@ -33,8 +34,8 @@ msgId2 = 0x12
 msgId1 = 0x11
 msgId0 = 0
 
-password = b"Sixteen byte key"
-passwordIv = b"Sixteen byte key"
+password = "Sixteen byte key"
+passwordIv = "Sixteen byte key"
 bright = 1
 sleep = 0
 font = 2
@@ -119,3 +120,206 @@ else:
         ("A", "S", "D", "F", "G", "tab"),
         ("Q", "W", "E", "R", "T", "alt"),
     )
+
+# ----------         End of Settings          ----------
+# ---------- Start read/write config.txt file ----------
+
+# File Open Modes
+# r -> read
+# rb -> read binary
+# w -> write
+# wb -> write binary
+# a -> append
+# ab -> append binary
+
+CONFIG_FILENAME = "config.txt"
+
+config_settings = set()
+config_excludeNames = {
+    "CONFIG_FILENAME",
+    "__file__",
+    "__name__",
+    "maxChars",
+    "maxLines",
+    "model"
+}
+config_includeTypes = {
+    float,
+    int,
+    str
+}
+
+
+def fileExists(fileName):
+    retVal = False
+
+    try:
+        with open(fileName, "r") as f:
+            f.readlines()
+            retVal = True
+    except OSError:
+        print(fileName + " does not exist")
+
+    return retVal
+
+
+def fileSystemWriteMode():
+    retVal = False
+    testFileName = "delete.txt"
+
+    try:
+        with open(testFileName, "w") as f:
+            f.write("test\n")
+            retVal = True
+
+        os.remove(testFileName)
+    except OSError:
+        print("Read Only File System")
+
+    return retVal
+
+
+def getConfigProperties():
+    my_globals = globals()
+    for g in my_globals:
+        if g not in config_excludeNames:
+            if type(globals()[g]) in config_includeTypes:
+                config_settings.add(g)
+
+
+# printConfigProperties is useful for debugging and may be removed
+def printConfigProperties():
+    i = 1
+    for c in config_settings:
+        # print(str(i) + chr(9) + c + chr(9) + str(globals()[c]))
+
+        if str(type(globals()[c])) == "<class 'str'>":
+            print(c + " = \"" + str(globals()[c]) + "\"")
+        else:
+            print(c + " = " + str(globals()[c]))
+        i = i + 1
+
+
+def readConfig(createIfNotExists=False):
+    if len(config_settings) == 0:
+        getConfigProperties()
+
+    if not fileExists(CONFIG_FILENAME):
+        if createIfNotExists:
+            writeConfig()
+        return False
+
+    with open(CONFIG_FILENAME, "r") as f:
+        conf = f.readlines()
+        print("Reading config:")
+        for line in conf:
+            if line.strip().startswith("#"):  # Ignore comment
+                continue
+
+            keyvalPair = line.split("=")
+
+            if(len(keyvalPair) != 2):  # Ignore not key value pair
+                continue
+
+            key = keyvalPair[0].strip()
+            value = keyvalPair[1].strip()
+
+            if key not in config_settings:  # Ignore key is not a setting
+                continue
+
+            if isinstance(globals()[key], str):
+                if value.startswith("\"") and value.endswith("\""):
+                    value = value[1:-1]
+                globals()[key] = value
+            elif isinstance(globals()[key], int):
+                globals()[key] = int(value)
+            elif isinstance(globals()[key], float):
+                globals()[key] = float(value)
+
+    return True
+
+
+def writeConfig():
+    if len(config_settings) == 0:
+        getConfigProperties()
+
+    if not fileSystemWriteMode():
+        print("Cannot write config file.")
+        print("Enable Write mode on device boot.")
+        return False
+
+    # Recover from previous failure #
+    # If the old config file exists, assume a failure last time.
+    # Copy the old config file back and try again.
+    # This will cause an issue if the original configuration file
+    # was the source of the issue and the code has not changed to
+    # address the issue.
+    if fileExists(CONFIG_FILENAME + ".old"):
+        if fileExists(CONFIG_FILENAME):
+            os.remove(CONFIG_FILENAME)
+        os.rename(CONFIG_FILENAME + ".old", CONFIG_FILENAME)
+
+    # if the config file exists, rename it then delete it
+    if fileExists(CONFIG_FILENAME):
+        os.rename(CONFIG_FILENAME, CONFIG_FILENAME + ".old")
+
+    # Create dict to track if items have been saved
+    configTrackDict = {}
+    for k in config_settings:
+        configTrackDict[k] = False
+
+    with open(CONFIG_FILENAME + ".old", "r") as f_old:
+        with open(CONFIG_FILENAME, "w") as f_new:
+            conf_old = f_old.readlines()
+            for line in conf_old:
+                if line.strip().startswith("#"):  # Comment
+                    if line.endswith("\n"):
+                        f_new.write(line)
+                    else:
+                        f_new.write(line + "\n")
+                    continue
+
+                keyvalPair = line.split("=")
+                if(len(keyvalPair) != 2):  # Not key value pair
+                    if line.endswith("\n"):
+                        f_new.write(line)
+                    else:
+                        f_new.write(line + "\n")
+                    continue
+
+                key = keyvalPair[0].strip()
+
+                if key not in config_settings:  # Ignore key is not a setting
+                    if line.endswith("\n"):
+                        f_new.write(line)
+                    else:
+                        f_new.write(line + "\n")
+                    continue
+
+                if isinstance(globals()[key], str):
+                    f_new.write(key + " = \"" + globals()[key] + "\"\n")
+                    configTrackDict[key] = True
+                else:
+                    f_new.write(key + " = " + str(globals()[key]) + "\n")
+                    configTrackDict[key] = True
+
+            for dkey, dval in configTrackDict.items():
+                if not dval:
+                    if isinstance(globals()[dkey], str):
+                        f_new.write(dkey + " = \"" + globals()[dkey] + "\"\n")
+                    else:
+                        f_new.write(dkey + " = " + str(globals()[dkey]) + "\n")
+
+    if fileExists(CONFIG_FILENAME + ".old"):
+        os.remove(CONFIG_FILENAME + ".old")
+
+    return True
+
+
+# print("--- Default Settings ---")
+# printConfigProperties()
+readConfig()
+# print("--- Configuration File Settings ---")
+# printConfigProperties()
+
+# writeConfig()


### PR DESCRIPTION
Now reading and writing to config.txt file to keep settings between reboots

Notes:
- If a new property is added to config.py, it will be written to config.txt if it is one of the types included in config_includeTypes list.
- A property may be excluded by placing it in the config_excludeNames list.

Limitations
- To save configuration changes, the filesytem needs to be changed to writable on boot by pressing the ALT key.
- If the config.txt file is edited by hand comments are allowed but the whole line must be a comment. Inline comments are not allowed.
- If a hex, binary. or octal value is in the config.txt file, it will be changed to decimal if the config file is saved.
- Currently only str, int, and float types are supported.