### PR TITLE
security: Updating AES mode to one that does not require a unique IV

### DIFF
--- a/Software/armachat.py
+++ b/Software/armachat.py
@@ -213,7 +213,7 @@ def sendMessage(text):
 
     # random.randint(min, max)
     outp = bytearray(len(text))
-    cipher = aesio.AES(config.password, aesio.MODE_CTR, config.passwordIv)
+    cipher = aesio.AES(config.password, aesio.MODE_CBC, config.passwordIv)
     cipher.encrypt_into(bytes(text, "utf-8"), outp)
     print("Send header:")
     print(hexlify(bytearray(header)))
@@ -312,7 +312,7 @@ def receiveMessage():
             packet_text = "D"
             return packet_text
         # Decrypt
-        cipher = aesio.AES(config.password, aesio.MODE_CTR, config.passwordIv)
+        cipher = aesio.AES(config.password, aesio.MODE_CBC, config.passwordIv)
         inp = bytes(packet[16:])
         outp = bytearray(len(inp))
         cipher.encrypt_into(inp, outp)


### PR DESCRIPTION
Looking at the config around the IV and the use of it in the code it seems that the system would encrypt more than one message with the same IV, making the messages vulnerable to attacks explained [here](https://crypto.stackexchange.com/questions/98239/proper-use-of-aes-ctr)

This PR changes the mode to CBC, which can use a fixed IV, and has minimal drawbacks. An alternative to this would be to use a nonce as the IV and send it along with the ciphertext for use in decryption.

Thanks!

